### PR TITLE
Fix string contains check in submit function

### DIFF
--- a/internal/resources/Submission.go
+++ b/internal/resources/Submission.go
@@ -30,7 +30,8 @@ func NewSubmission(data *http.Response, answer string) (*Submission, error) {
 		message: message,
 	}
 
-	if strings.Contains(message, "right answer") || strings.Contains(message, "Congratulations!") {
+	if strings.Contains(message, "That's the right answer!") ||
+		strings.Contains(message, "Congratulations!") {
 		newSub.correct = true
 	} else {
 		newSub.correct = false


### PR DESCRIPTION
## Summary

Fix Issue #50 

When submitting an answer, the returned message is usually something like `"That's not the right answer.  If you're stuck, make sure you're using the full input data; there are also some general tips on the about page, or you can ask for hints on the subreddit."` 

The check `if strings.Contains(message, "right answer")` was evaluating to `true` since the string did in fact contain that substring.

Fixed the conditional to be more specific and check exactly for the string `"That's the right answer!"`
